### PR TITLE
Change # of news displayed to 5

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -52,8 +52,8 @@ function App() {
   const allNewsData = getSortedNewsData();
   return (
     <>
-      {allNewsData.slice(0, 4).map((newsData: NewsDataType, index: number) => {
-        return index === 3 ? (
+      {allNewsData.slice(0, 5).map((newsData: NewsDataType, index: number) => {
+        return index === 4 ? (
           <React.Fragment key={newsData.id}>
             <NewsItem {...newsData} />
           </React.Fragment>


### PR DESCRIPTION
* Adding a new News item caused the ERDDAP entry to be bumped off the news feed
* During the weekly meeting, it was decided to keep displaying the ERDDAP entry since it's the only location for those links on the website
* To accommodate the ERDDAP entry, I will try to update the display count of news items from 4 to 5