### PR TITLE
Add Pinned functionality and Cruise-Updates entry 

### DIFF
--- a/news/2025-03-24-cruise_updates_pinned.md
+++ b/news/2025-03-24-cruise_updates_pinned.md
@@ -1,0 +1,11 @@
+---
+title: New Monthly Data & Cruise Report Updates Page
+date: "2025-03-24"
+pinned: true
+---
+
+We've launched a new [Monthly Data & Cruise Report Updates](/cruise-updates) page to share updates of newly processed data and cruise report.
+
+Instead of publishing individual news items each month, updates will now be posted directly to this dedicated page in an easy-to-browse format.
+
+Visit the [updates page](/cruise-updates) to see the most recent changes.

--- a/news/2025-03-24-cruise_updates_pinned.md
+++ b/news/2025-03-24-cruise_updates_pinned.md
@@ -6,6 +6,4 @@ pinned: true
 
 We've launched a new [Monthly Data & Cruise Report Updates](/cruise-updates) page to share updates of newly processed data and cruise report.
 
-Instead of publishing individual news items each month, updates will now be posted directly to this dedicated page in an easy-to-browse format.
-
 Visit the [updates page](/cruise-updates) to see the most recent changes.

--- a/news/2025-03-24-cruise_updates_pinned.md
+++ b/news/2025-03-24-cruise_updates_pinned.md
@@ -4,6 +4,6 @@ date: "2025-03-24"
 pinned: true
 ---
 
-We've launched a new [Monthly Data & Cruise Report Updates](/cruise-updates) page to share updates of newly processed data and cruise report.
+We've launched a [Monthly Data & Cruise Report Updates](/cruise-updates) page to share updates of newly processed data and cruise report.
 
 Visit the [updates page](/cruise-updates) to see the most recent changes.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -30,6 +30,10 @@ export function getSortedNewsData() {
   );
   // Sort posts by date
   return allNewssData.sort((a, b) => {
+    // If either item is pinned, it should come first
+    if (a.pinned && !b.pinned) return -1;
+    if (!a.pinned && b.pinned) return 1;
+    // If both are pinned or both are unpinned, sort by date
     if (a.date < b.date) {
       return 1;
     } else {
@@ -38,10 +42,13 @@ export function getSortedNewsData() {
   });
 }
 
-const NewsItem = ({ contentMarkdown, date, title }: NewsDataType) => {
+const NewsItem = ({ contentMarkdown, date, title, pinned }: NewsDataType) => {
   return (
     <>
-      <h5>{title}</h5>
+      <h5>
+        {pinned && <i className="fa-solid fa-thumbtack text-primary" style={{ marginRight: '8px' }}></i>}
+        {title}
+      </h5>
       <small>{date}</small>
       <ReactMarkdown remarkPlugins={[gfm]}>{contentMarkdown}</ReactMarkdown>
     </>


### PR DESCRIPTION
Based on discussions we at last month's tech meeting, this is the idea to create a "pinned" news item to direct users to the monthly cruise updates page 